### PR TITLE
Fix compatibility with newer Hive >0.12 data Types

### DIFF
--- a/RHive/R/rhive.R
+++ b/RHive/R/rhive.R
@@ -352,7 +352,7 @@
     for (i in seq.int(length(colTypes))) {
       colType <- colTypes[i]
       colName <- colNames[i]
-      if (colType == "string") {
+      if (  any(colType %in% c("string","varchar","timestamp","date","char")) )  {
         lst[[i]] <- character()
       } else if (length(grep("^array", colType)) > 0) {
         lst[[i]] <- character()


### PR DESCRIPTION
# Fixes issue 84

This patch is not mine, its from winghc, but I also need the fix, and I tested it locally, it works perfectly:

https://github.com/nexr/RHive/issues/84
